### PR TITLE
Feature/pi5 setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 Install scripts and utilities for setting up MBot environment on Ubuntu/Debian
 
 ### Setting up a fresh image ###
-> This is for mbot using Pi4 or Jetson Nano
-
 1. Install dependencies using scripts in install_scripts directory.
 ```bash
 sudo ./install_scripts/install_mbot_dependencies.sh
@@ -16,10 +14,15 @@ sudo ./install_scripts/install_nomachine.sh   # Recommended for debugging.
 sudo ./install_scripts/install_vscode.sh      # Only if you want to develop on the Pi.
 ```
 
-3. Copy mbot_config.txt to the proper loacation in the boot folder. On Ubuntu 22.04 this is `/boot/firmware`, on Raspberry Pi OS this is just `/boot`:
-```bash
-sudo cp mbot_config.txt [/boot, /boot/firmware]
-```
+3. Copy mbot_config.txt to the proper loacation in the boot folder.
+   - On Ubuntu 22.04 and Raspberry Pi 5 this is `/boot/firmware`
+    ```bash
+    sudo cp mbot_config.txt /boot/firmware
+    ```
+   - on Raspberry Pi 4 this is just `/boot`:
+    ```bash
+    sudo cp mbot_config.txt /boot
+    ```
 
 4. Edit the configuration:
 ```bash

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 Install scripts and utilities for setting up MBot environment on Ubuntu/Debian
 
 ### Setting up a fresh image ###
+> This is for mbot using Pi4 or Jetson Nano
 
 1. Install dependencies using scripts in install_scripts directory.
 ```bash

--- a/install_scripts/install_mbot_dependencies.sh
+++ b/install_scripts/install_mbot_dependencies.sh
@@ -20,7 +20,7 @@ apt -y install mesa-common-dev libgl1-mesa-dev libglu1-mesa-dev
 apt -y install python3-dev python3-numpy python3-matplotlib python3-opencv python3-scipy python3-pygame python3-pip
 
 # Install python pkgs for MBot OLED
-pip3 install luma.oled qrcode
+apt -y install python3-qrcode python3-luma.oled
 
 #### Enable features for specific platforms ####
 # Check if running on RPi

--- a/rpi5_config.txt
+++ b/rpi5_config.txt
@@ -1,0 +1,2 @@
+# https://www.raspberrypi.com/documentation/computers/config_txt.html
+# This file name should be included in the /boot/firmware/config.txt already

--- a/rpi_config.txt
+++ b/rpi_config.txt
@@ -1,3 +1,6 @@
+# As of June 2024, this file is legacy settings that are no longer
+# used by RPi OS Bookworm.
+
 # For more options and information see
 # http://rpf.io/configtxt
 # Some settings may impact device functionality. See link above for details

--- a/services/mbot_start_networking.py
+++ b/services/mbot_start_networking.py
@@ -5,11 +5,12 @@ import datetime
 import subprocess
 # Define the path to the config file
 is_ubuntu = 'Ubuntu' in subprocess.check_output(['cat', '/etc/os-release']).decode('utf-8')
-is_raspios = 'Raspberry Pi OS' in subprocess.check_output(['cat', '/etc/os-release']).decode('utf-8')
+is_pi4 = 'Raspberry Pi OS' in subprocess.check_output(['cat', '/etc/os-release']).decode('utf-8')
+is_pi5 = 'bookworm' in subprocess.check_output(['cat', '/etc/os-release']).decode('utf-8')
 
-if(is_ubuntu):
+if(is_ubuntu or is_pi5):
     config_file = "/boot/firmware/mbot_config.txt"
-else:
+elif is_pi4:
     config_file = "/boot/mbot_config.txt"
 
 # Check devices then assign GPIO Numbers,


### PR DESCRIPTION
### Why:
#### 1. Change in services/mbot_start_networking.py and the README.md instruction
The Pi 5 bookworm's `bootfs` partition is mounted to `/boot/firmware`, unlike Pi 4 mounted to `/boot`. We need to modify mbot_config.txt related code in `mbot_sys_utils` by adding things like 

```python
if is_ubuntu or is_pi5: 
  check(`/boot/firmware`)
elif is_pi4: 
  check(`/boot`)
```

If we do not make this change, and following the Pi 4's instruction, then to modify the `mbot_config.txt` on pi 5 before boot up, the student would have to: 1)find a linux machine, 2)go to the `rootfs` partition and go to `/boot` to find `mbot_config.txt`. Mac and windows can only see `bootfs` which mounted to `/boot/firmware`.

#### 2. Change in install scripts
The new Pi OS bookworm don't like people do pip install in system-wise and force users to do apt install unless using python virtual env. As a workaround for now, we change the pip install to apt install.
    