### PR TITLE
pi5 PIN issue resolved

### DIFF
--- a/services/mbot_start_networking.py
+++ b/services/mbot_start_networking.py
@@ -18,10 +18,14 @@ elif is_pi4:
 # on RPi pin 7 is gpio4, pin 11 is gpio17
 with open('/proc/device-tree/model', 'r') as file:
     data = file.read()
-if "Raspberry Pi" in data:
-    print("Detected Raspberry Pi")
+if "Raspberry Pi 4" in data:
+    print("Detected Raspberry Pi 4")
     BTLD_PIN = 4
     RUN_PIN = 17
+elif "Raspberry Pi 5" in data:
+    print("Detected Raspberry Pi 5")
+    BTLD_PIN=588
+    RUN_PIN=575
 elif "NVIDIA Jetson" in data:
     print("Detected NVIDIA Jetson")
     BTLD_PIN = 50


### PR DESCRIPTION
Same issue what we had for [mbot_firmware](https://github.com/mbot-project/mbot_firmware/pull/3) upload.sh, the Raspberry Pi 5 uses a different PIN numbering system, which causes the mbot-start-network.service to fail. This change will sovle the problem.