### PR TITLE
Fix IP reporting

### DIFF
--- a/mbot_config.txt
+++ b/mbot_config.txt
@@ -4,5 +4,5 @@ new_wifi_ssid=HomeWifiSSID
 new_wifi_password=HomeWifiPassword
 mbot_ip_list_url=https://github.com/MBot-Project-Development/mbot_ip_registry.git
 mbot_ip_list_user=mbotinfo
-mbot_ip_list_token=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
+mbot_ip_list_token=
 autostart=run

--- a/services/mbot_publish_info.sh
+++ b/services/mbot_publish_info.sh
@@ -3,18 +3,18 @@
 set -e  # Quit on error.
 
 wait_for_ip() {
-    echo "Waiting $TIMEOUT seconds for IP..." &>> $LOG
+    echo "Waiting $TIMEOUT seconds for IP..." | tee -a $LOG
     count=0
     while [ -z $IP ]; do
         if [ $count -gt $TIMEOUT ]; then
-            echo "Timed out waiting for IP. Exiting." &>> $LOG
+            echo "Timed out waiting for IP. Exiting." | tee -a $LOG
             exit 0
         fi
         sleep 1
         IP=$(hostname -I | awk '{print $1}')
         count=$((count+1))
     done
-    echo "Got IP after $count seconds." &>> $LOG
+    echo "Got IP after $count seconds." | tee -a $LOG
 }
 
 HOSTNAME=$(hostname)
@@ -22,13 +22,17 @@ IP=$(hostname -I | awk '{print $1}')
 LOG_PATH="/var/log/mbot"
 mkdir -p $LOG_PATH
 LOG="$LOG_PATH/mbot_publish_info.log"
-if [ "$(lsb_release -is)" = "Ubuntu" ]; then
+if [ -f "/boot/mbot_config.txt" ]; then
+    CONFIG_FILE="/boot/mbot_config.txt"
+    IP_OUT_FILE="/boot/ip_out.txt"
+elif [ -f "/boot/firmware/mbot_config.txt" ]; then
     CONFIG_FILE="/boot/firmware/mbot_config.txt"
     IP_OUT_FILE="/boot/firmware/ip_out.txt"
 else
-    CONFIG_FILE="/boot/mbot_config.txt"
-    IP_OUT_FILE="/boot/ip_out.txt"
+    echo "ERROR: No MBot configuration file found." | tee -a $LOG
+    exit 1
 fi
+
 GIT_USER=$(grep "^mbot_ip_list_user=" $CONFIG_FILE | cut -d'=' -f2)
 GIT_TOKEN=$(grep "^mbot_ip_list_token=" $CONFIG_FILE | cut -d'=' -f2)
 GIT_URL=$(grep "^mbot_ip_list_url=" $CONFIG_FILE | cut -d'=' -f2)
@@ -36,33 +40,37 @@ GIT_ADDR=${GIT_URL#*://}
 GIT_PATH="/var/tmp/mbot_ip_registry"
 TIMEOUT=30
 
-echo $(date) &>> $LOG
-echo "Updating IP" &>> $LOG
-echo "Hostname= $HOSTNAME" &>> $LOG
+echo $(date) | tee -a $LOG
+echo "Updating IP" | tee -a $LOG
+echo "Hostname= $HOSTNAME" | tee -a $LOG
 if [ -z $IP ]; then
     wait_for_ip
 fi
-echo "IP= $IP" &>> $LOG
+echo "IP= $IP" | tee -a $LOG
 echo "My IP is $IP!" > $IP_OUT_FILE
 
+if [ -d "$GIT_PATH" ]; then
+    rm -rf $GIT_PATH
+fi
+
 if [ ! -d "$GIT_PATH" ]; then
-    git clone --depth=1 "https://$GIT_USER:$GIT_TOKEN@$GIT_ADDR" "$GIT_PATH"
+    git clone --depth=1 "https://$GIT_USER:$GIT_TOKEN@$GIT_ADDR" "$GIT_PATH" | tee -a $LOG
 fi
 
 git -C $GIT_PATH config --local user.email "$GIT_USER"
 git -C $GIT_PATH config --local user.name "$GIT_USER"
 #git config pull.rebase false
-git -C $GIT_PATH pull https://$GIT_USER:$GIT_TOKEN@$GIT_ADDR &>> $LOG
+git -C $GIT_PATH pull https://$GIT_USER:$GIT_TOKEN@$GIT_ADDR | tee -a $LOG
 
-echo "Calling python script" &>> $LOG
+echo "Calling python script" | tee -a $LOG
 python3 $GIT_PATH/register_mbot.py -hostname $HOSTNAME -ip $IP -log $LOG
-echo "Adding..." &>> $LOG
-git -C $GIT_PATH/ add data/$HOSTNAME.json &>> $LOG
-echo "Committing..." &>> $LOG
-git -C $GIT_PATH/ commit -m "Auto update $HOSTNAME IP" &>> $LOG
-echo "Pushing..." &>> $LOG
-git -C $GIT_PATH/ push https://$GIT_USER:$GIT_TOKEN@$GIT_ADDR &>> $LOG
-echo "Deleting local copy..." &>> $LOG
+echo "Adding..." | tee -a $LOG
+git -C $GIT_PATH/ add data/$HOSTNAME.json | tee -a $LOG
+echo "Committing..." | tee -a $LOG
+git -C $GIT_PATH/ commit -m "Auto update $HOSTNAME IP" | tee -a $LOG
+echo "Pushing..." | tee -a $LOG
+git -C $GIT_PATH/ push https://$GIT_USER:$GIT_TOKEN@$GIT_ADDR | tee -a $LOG
+echo "Deleting local copy: $GIT_PATH" | tee -a $LOG
 rm -rf $GIT_PATH
-echo "Done, exiting" &>> $LOG
+echo "Done, exiting" | tee -a $LOG
 exit 0


### PR DESCRIPTION
Reporting the IP via git repo was not working on the new Pi 5 image because of incorrectly identifying the location of the config. This PR has the following changes:

1. The script checks which file exists, `/boot/mbot_config.txt` or `/boot/firmware/mbot_config.txt`, before running, instead of guessing from the OS type. If neither, it fails.
2. If there is no or incomplete Git information in the config, the script does not attempt to push to git.
3. Cleaned up logging so that both the status and the log pick up all messages.
4. Removed the GitHub token by default

Fixes #3 