### PR TITLE
Update ROS OLED script to sync with mbot_firmware_ros

### DIFF
--- a/ros2_mbot_sys_utils/services/mbot_ros_oled_display.py
+++ b/ros2_mbot_sys_utils/services/mbot_ros_oled_display.py
@@ -14,6 +14,15 @@ import signal
 
 import rclpy
 from rclpy.node import Node
+from rclpy.qos import QoSProfile, QoSReliabilityPolicy
+
+# This is for the battery subscription.
+# To be compatible with the firmware, best effort is used.
+qos_profile = QoSProfile(
+    depth=10,
+    reliability=QoSReliabilityPolicy.BEST_EFFORT
+)
+
 # Attempt to import the custom BatteryADC message. If it is unavailable we will
 # continue to run the application, but omit the battery-level subscription.
 try:
@@ -91,7 +100,7 @@ class MBotOLED:
                     BatteryADC,
                     'battery_adc',  # Topic name must match the publisher in mbot firmware
                     self.battery_info_callback,
-                    10  # QoS depth
+                    qos_profile
                 )
                 logging.info("Battery subscription created successfully.")
             else:


### PR DESCRIPTION
Since we changed the Battery_ADC publisher QoS to best effort in mbot_firmware_ros ([Pull Request](https://github.com/mbot-project/mbot_firmware_ros/pull/9)), now the OLED display code also need to be updated. If the ROS listener is still expecting reliable QoS message, the battery screen will show “???”. 

With the image generated on 7/11/2025, the OLED battery screen will not work with the latest firmware, unless pull the latest update from mbot_sys_utils.