### PR TITLE
Improved install_mbot_ros_services.sh

### DIFF
--- a/ros2_mbot_sys_utils/services/install_mbot_ros_services.sh
+++ b/ros2_mbot_sys_utils/services/install_mbot_ros_services.sh
@@ -18,15 +18,11 @@ do
     sudo cp $serv.service /etc/systemd/system/$serv.service
 done
 
-# Enable time sync wait service
-sudo systemctl enable --now systemd-time-wait-sync.service
-
 # Enable the services.
 sudo systemctl daemon-reload
 for serv in $SERVICE_LIST
 do
     sudo systemctl enable $serv.service
-    sudo systemctl start $serv.service
 done
 
 # Success message.


### PR DESCRIPTION
No need to run the time sync at image generate step, and no need to start the service, microros service dependency will make the script hang forever.